### PR TITLE
Board representation (fixes #11)

### DIFF
--- a/Backend.cpp
+++ b/Backend.cpp
@@ -1,0 +1,46 @@
+#include "Backend.hpp"
+#include "globalVars.hpp"
+#include <iostream>
+
+using namespace std;
+
+
+void addDotsToBoard(int n){
+    for(int i = 0; i < 2 * n - 1; i++){
+        for(int j = 0; j < 2 * n - 1; j++){
+            if((i + j) % 2 == 0){
+                board[i][j] = '0';
+            }
+            else if(i % 2 == 0 && j % 2 == 1){
+                board[i][j] = 'x';
+            }
+            else{
+                board[i][j] = 'y';
+            }
+        }
+    }
+    board[0][0] = '-';
+    board[0][2 * n - 2] = '-';
+    board[2 * n - 2][0] = '-';
+    board[2 * n - 2][2 * n - 2] = '-';
+}
+
+void printBoard(int n){
+    for(int i = 0; i < 2 * n - 1; i++){
+        for(int j = 0; j < 2 * n - 1; j++){
+            cout << board[i][j] << " ";
+        }
+        cout << endl;
+    }
+}
+
+void createBoard(int n){
+    board = new char*[2 * n - 1];
+    for(int i = 0; i < 2 * n - 1; i++){
+        board[i] = new char[2 * n - 1];
+    }
+    cout << "Si asta a mers" << endl;
+    addDotsToBoard(n);
+    cout << "Am terminat tot si nu stiu care mai e problema" << endl;
+    printBoard(n);
+}

--- a/Backend.hpp
+++ b/Backend.hpp
@@ -1,0 +1,3 @@
+#include "macros.hpp"
+
+void createBoard(int n);

--- a/Bridg-It.cbp
+++ b/Bridg-It.cbp
@@ -32,8 +32,11 @@
 			<Add option="-Wall" />
 			<Add option="-fexceptions" />
 		</Compiler>
+		<Unit filename="Backend.cpp" />
+		<Unit filename="Backend.hpp" />
 		<Unit filename="UI.cpp" />
 		<Unit filename="UI.hpp" />
+		<Unit filename="globalVars.hpp" />
 		<Unit filename="macros.hpp" />
 		<Unit filename="main.cpp" />
 		<Extensions>

--- a/globalVars.hpp
+++ b/globalVars.hpp
@@ -1,0 +1,1 @@
+char **board;


### PR DESCRIPTION
I have created another header for global variables we might need to use, and that's my idea of an internal representation of the board. The fields filled with '-' are the useless ones, the ones filled with 'x' represent the first player's dots, and the ones filled with 'y' the second player's dots. The ones filled with '0' are available connections. Once the first player makes a connection using that road, it would turn to a '1', and for the second player, to a '2'.